### PR TITLE
Fix(tests): Align whitelist success message assertion with actual API…

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -351,8 +351,13 @@ class RouteTestCase(unittest.TestCase):
                                         json={'username': 'whitelisted_dude'})
             self.assertEqual(response.status_code, 200)
             data = response.get_json()
-            self.assertIn('access granted to whitelisted_dude', data['message'])
-            self.assertIn('Sharable Recipe', data['message']) # Check recipe name is in message
+
+            self.assertIn(f"Recipe '{recipe_to_share.name}'", data['message']) # Check if recipe name is mentioned
+            self.assertIn(f"shared with {user_to_whitelist.username}", data['message']) # Check if user is mentioned and "shared with"
+            
+            expected_message = f"Recipe '{recipe_to_share.name}' shared with {user_to_whitelist.username}."
+            self.assertEqual(data['message'], expected_message)
+
 
             db.session.refresh(recipe_to_share) 
             self.assertIn(user_to_whitelist.id, recipe_to_share.whitelist)


### PR DESCRIPTION
… response

The `test_add_to_whitelist_route` was failing due to a mismatch between the expected success message and the actual message returned by the `/recipes/<id>/whitelist` API endpoint.

The API's success message was updated (likely in a previous commit by a teammate) to be more descriptive, e.g., "Recipe '<Recipe Name>' shared with <Username>." while the test still expected an older format containing "access granted to <Username>".

This commit updates the assertion in `test_add_to_whitelist_route` to expect the current, correct message format, ensuring the test accurately reflects the API's behavior.